### PR TITLE
Legacy support tiles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.4.0
+-----
+
+* Add tile `enforcer-legacy` to allow Maven 3.3.9+
+* Rename artifacts to remove redundant `-tile` suffixes
+* Prevent installation of the root pom
+
 0.3.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ For Java 9 and Maven 3.5.0+ applications:
 
 Where Maven 3.3.9 is required, add the `enforcer-legacy-tile`.
 
+Where Java 1.8 is required set the `java.version` property to `1.8`.
+
 ### Properties
 
 If you want to override the version or configuration values of any of the plugins configured by the tiles, you can set the following properties to the desired value.

--- a/README.md
+++ b/README.md
@@ -22,24 +22,23 @@ For Java 9 and Maven 3.5.0+ applications:
                 <extensions>true</extensions>
                 <configuration>
                     <tiles>
-                         <tile>net.kemitix.tiles:all-tiles:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:all:${kemitix-tiles.version}</tile>
 
                          <!-- or -->
 
-                         <tile>net.kemitix.tiles:maven-plugins-tile:${kemitix-tiles.version}</tile>
-                         <tile>net.kemitix.tiles:enforcer-tile:${kemitix-tiles.version}</tile>
-                         <tile>net.kemitix.tiles:compiler-tile:${kemitix-tiles.version}</tile>
-                         <tile>net.kemitix.tiles:huntbugs-tile:${kemitix-tiles.version}</tile>
-                         <tile>net.kemitix.tiles:pmd-tile:${kemitix-tiles.version}</tile>
-                         <tile>net.kemitix.tiles:digraph-tile:${kemitix-tiles.version}</tile>
-                         <tile>net.kemitix.tiles:testing-tile:${kemitix-tiles.version}</tile>
-                         <tile>net.kemitix.tiles:coverage-tile:${kemitix-tiles.version}</tile>
-                         <tile>net.kemitix.tiles:release-tile:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:maven-plugins:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:enforcer:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:compiler:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:huntbugs:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:digraph:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:testing:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:coverage:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:release:${kemitix-tiles.version}</tile>
 
                          <!-- Java 8 only - not compatible with Java 9+ -->
-                         <tile>net.kemitix.tiles:pmd-tile:${kemitix-tiles.version}</tile>
-                         <tile>net.kemitix.tiles:pitest-tile:${kemitix-tiles.version}</tile>
-                         <tile>net.kemitix.tiles:huntbugs-tile:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:pmd:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:pitest:${kemitix-tiles.version}</tile>
+                         <tile>net.kemitix.tiles:huntbugs:${kemitix-tiles.version}</tile>
 
                    </tiles>
                 </configuration>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For Java 9 and Maven 3.5.0+ applications:
 </project>
 ```
 
-Where Maven 3.3.9 is required, add the `enforcer-legacy-tile`.
+Where Maven 3.3.9 is required, add the `enforcer-legacy`.
 
 Where Java 1.8 is required set the `java.version` property to `1.8`.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Maven Tiles for preconfigured plugins.
 
 ### Usage
 
+For Java 9 and Maven 3.5.0+ applications:
+
 ```xml
 <project>
     <properties>
@@ -46,6 +48,8 @@ Maven Tiles for preconfigured plugins.
     </build>
 </project>
 ```
+
+Where Maven 3.3.9 is required, add the `enforcer-legacy-tile`.
 
 ### Properties
 

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>all-tiles</artifactId>
+    <artifactId>all</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/all/tile.xml
+++ b/all/tile.xml
@@ -8,16 +8,16 @@
                 <extensions>true</extensions>
                 <configuration>
                     <tiles>
-                        <tile>net.kemitix.tiles:maven-plugins-tile:0.4.0-SNAPSHOT</tile>
-                        <tile>net.kemitix.tiles:enforcer-tile:0.4.0-SNAPSHOT</tile>
-                        <tile>net.kemitix.tiles:compiler-tile:0.4.0-SNAPSHOT</tile>
-                        <tile>net.kemitix.tiles:huntbugs-tile:0.4.0-SNAPSHOT</tile>
-                        <tile>net.kemitix.tiles:pmd-tile:0.4.0-SNAPSHOT</tile>
-                        <tile>net.kemitix.tiles:digraph-tile:0.4.0-SNAPSHOT</tile>
-                        <tile>net.kemitix.tiles:testing-tile:0.4.0-SNAPSHOT</tile>
-                        <tile>net.kemitix.tiles:coverage-tile:0.4.0-SNAPSHOT</tile>
-                        <tile>net.kemitix.tiles:pitest-tile:0.4.0-SNAPSHOT</tile>
-                        <tile>net.kemitix.tiles:release-tile:0.4.0-SNAPSHOT</tile>
+                        <tile>net.kemitix.tiles:maven-plugins:0.4.0-SNAPSHOT</tile>
+                        <tile>net.kemitix.tiles:enforcer:0.4.0-SNAPSHOT</tile>
+                        <tile>net.kemitix.tiles:compiler:0.4.0-SNAPSHOT</tile>
+                        <tile>net.kemitix.tiles:huntbugs:0.4.0-SNAPSHOT</tile>
+                        <tile>net.kemitix.tiles:pmd:0.4.0-SNAPSHOT</tile>
+                        <tile>net.kemitix.tiles:digraph:0.4.0-SNAPSHOT</tile>
+                        <tile>net.kemitix.tiles:testing:0.4.0-SNAPSHOT</tile>
+                        <tile>net.kemitix.tiles:coverage:0.4.0-SNAPSHOT</tile>
+                        <tile>net.kemitix.tiles:pitest:0.4.0-SNAPSHOT</tile>
+                        <tile>net.kemitix.tiles:release:0.4.0-SNAPSHOT</tile>
                     </tiles>
                 </configuration>
             </plugin>

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>compiler-tile</artifactId>
+    <artifactId>compiler</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>coverage-tile</artifactId>
+    <artifactId>coverage</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/digraph/pom.xml
+++ b/digraph/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>digraph-tile</artifactId>
+    <artifactId>digraph</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/enforcer-legacy/pom.xml
+++ b/enforcer-legacy/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tiles-parent</artifactId>
+        <groupId>net.kemitix.tiles</groupId>
+        <version>0.4.0-SNAPSHOT</version>
+        <relativePath>../tiles-parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>enforcer-legacy-tile</artifactId>
+    <packaging>tile</packaging>
+
+</project>

--- a/enforcer-legacy/pom.xml
+++ b/enforcer-legacy/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>enforcer-legacy-tile</artifactId>
+    <artifactId>enforcer-legacy</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/enforcer-legacy/pom.xml
+++ b/enforcer-legacy/pom.xml
@@ -3,10 +3,10 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/enforcer-legacy/tile.xml
+++ b/enforcer-legacy/tile.xml
@@ -1,0 +1,32 @@
+<project>
+    <properties>
+        <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
+        <required-maven.version>3.3.9</required-maven.version>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>display-info</goal>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <requireMavenVersion>
+                            <version>${required-maven.version}</version>
+                        </requireMavenVersion>
+                    </rules>
+                </configuration>
+            </plugin><!-- maven-enforcer-plugin -->
+        </plugins>
+    </build>
+</project>

--- a/enforcer/pom.xml
+++ b/enforcer/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>enforcer-tile</artifactId>
+    <artifactId>enforcer</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/huntbugs/pom.xml
+++ b/huntbugs/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>huntbugs-tile</artifactId>
+    <artifactId>huntbugs</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>maven-plugins-tile</artifactId>
+    <artifactId>maven-plugins</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>tiles-parent</artifactId>
+    <artifactId>parent</artifactId>
     <packaging>pom</packaging>
 
     <properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -13,6 +13,7 @@
     <packaging>pom</packaging>
 
     <properties>
+        <maven.install.skip>false</maven.install.skip>
         <tiles-maven-plugin.version>2.10</tiles-maven-plugin.version>
     </properties>
 

--- a/pitest/pom.xml
+++ b/pitest/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>pitest-tile</artifactId>
+    <artifactId>pitest</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/pmd/pom.xml
+++ b/pmd/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>pmd-tile</artifactId>
+    <artifactId>pmd</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <description>Maven Tiles for preconfigured plugins</description>
 
     <modules>
-        <module>tiles-parent</module>
+        <module>parent</module>
         <module>compiler</module>
         <module>release</module>
         <module>digraph</module>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     </modules>
 
     <properties>
+        <maven.install.skip>true</maven.install.skip>
         <maven-javadoc-plugin.version>3.0.0-M1</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>release-tile</artifactId>
+    <artifactId>release</artifactId>
     <packaging>tile</packaging>
 
 </project>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -3,14 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>tiles-parent</artifactId>
+        <artifactId>parent</artifactId>
         <groupId>net.kemitix.tiles</groupId>
         <version>0.4.0-SNAPSHOT</version>
-        <relativePath>../tiles-parent/pom.xml</relativePath>
+        <relativePath>../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>testing-tile</artifactId>
+    <artifactId>testing</artifactId>
     <packaging>tile</packaging>
 
 </project>


### PR DESCRIPTION
* Add tile `enforcer-legacy` to allow Maven 3.3.9+
* Rename artifacts to remove redundant `-tile` suffixes
* Prevent installation of the root pom