### PR TITLE
Remove highwheel-maven-plugin

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -5,6 +5,12 @@
   The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]], and this project adheres to
   [[https://semver.org/spec/v2.0.0.html][Semantic Versioning]].
 
+* 2.2.0 - 2019-03-03
+
+** Removed
+
+   - [pitest] highwheel-mavel-plugin - [[https://github.com/hcoles/highwheel/pull/12][JDK 11 compatibility]]
+
 * 2.1.4 - 2019-02-02
 
 ** Dependencies

--- a/README.org
+++ b/README.org
@@ -250,8 +250,8 @@
      The [[http://pitest.org/quickstart/maven/][Pitest Maven Plugin]] perform mutation test coverage checks during the
      `verify` phase.
 
-     Code coverage must by 100%. The build will fail if any mutation does not
-     result in test failing.
+     Code coverage must by 100%, see `pitest.coverage`. The build will
+     fail if any mutation does not result in test failing.
 
      Set `pitest.skip` to avoid running the mutation testing.
 

--- a/README.org
+++ b/README.org
@@ -245,8 +245,6 @@
 
 *** pitest
 
-    The plugins in this tile are only enabled when using a 1.8 JDK.
-
 **** Mutation Testing
 
      The [[http://pitest.org/quickstart/maven/][Pitest Maven Plugin]] perform mutation test coverage checks during the

--- a/README.org
+++ b/README.org
@@ -12,7 +12,7 @@
    #+BEGIN_SRC xml
      <project>
        <properties>
-         <tiles-maven-plugin.version>2.12</tiles-maven-plugin.version>
+         <tiles-maven-plugin.version>2.13</tiles-maven-plugin.version>
          <kemitix-tiles.version>DEV-SNAPSHOT</kemitix-tiles.version>
        </properties>
        <build>

--- a/pitest/pom.xml
+++ b/pitest/pom.xml
@@ -14,10 +14,9 @@
     <packaging>tile</packaging>
 
     <name>kemitix-maven-tiles-pitest</name>
-    <description>{pitest,highwheel}-maven plugins for kemitix-maven-tiles</description>
+    <description>pitest-maven plugins for kemitix-maven-tiles</description>
 
     <properties>
-        <highwheel-maven-plugin.version>1.4</highwheel-maven-plugin.version>
         <pitest-maven-plugin.version>1.4.5</pitest-maven-plugin.version>
         <pitest-junit5-plugin.version>0.8</pitest-junit5-plugin.version>
     </properties>
@@ -25,11 +24,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.pitest</groupId>
-                    <artifactId>highwheel-maven</artifactId>
-                    <version>${highwheel-maven-plugin.version}</version>
-                </plugin>
                 <plugin>
                     <groupId>org.pitest</groupId>
                     <artifactId>pitest-maven</artifactId>

--- a/pitest/tile.xml
+++ b/pitest/tile.xml
@@ -1,6 +1,5 @@
 <project>
     <properties>
-        <highwheel-maven-plugin.version>@highwheel-maven-plugin.version@</highwheel-maven-plugin.version>
         <pitest-maven-plugin.version>@pitest-maven-plugin.version@</pitest-maven-plugin.version>
         <pitest-junit5-plugin.version>@pitest-junit5-plugin.version@</pitest-junit5-plugin.version>
         <pitest.coverage>0</pitest.coverage>
@@ -10,19 +9,6 @@
     </properties>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.pitest</groupId>
-                <artifactId>highwheel-maven</artifactId>
-                <version>${highwheel-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>analyse</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin><!-- highwheel-maven -->
             <plugin>
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>


### PR DESCRIPTION
**Remove highwheel-maven-plugin**
It is not compatible with JDK 11. If the PR
https://github.com/hcoles/highwheel/pull/12 is merged, then we can
look at adding it back in.

**[readme] Update version of tiles-mave-plugin used in example**

**[readme] remove note about pitest tile only being enabled for JDK 8**

**[readme] add note about pitest and coverage**