### PR TITLE
[compiler-jdk{8,11] Expose maven.compiler.{source,target} properties

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -5,6 +5,12 @@
   The format is based on [[https://keepachangelog.com/en/1.0.0/][Keep a Changelog]], and this project adheres to
   [[https://semver.org/spec/v2.0.0.html][Semantic Versioning]].
 
+* 2.4.1 - 2020-03-19
+
+** Fixed
+
+   - Expose maven.compiler.{source,target} for IDEs (#
+
 * 2.4.0 - 2020-03-17
 
 ** Changed

--- a/compiler-jdk-11/tile.xml
+++ b/compiler-jdk-11/tile.xml
@@ -1,6 +1,8 @@
 <project>
     <properties>
         <java.version>@java.compiler.version@</java.version>
+        <maven.compiler.source>@java.compiler.version@</maven.compiler.source>
+        <maven.compiler.target>@java.compiler.version@</maven.compiler.target>
         <maven-compiler-plugin.version>@maven-compiler-plugin.version@</maven-compiler-plugin.version>
         <project.build.sourceEncoding>@project.build.sourceEncoding@</project.build.sourceEncoding>
     </properties>

--- a/compiler-jdk-8/tile.xml
+++ b/compiler-jdk-8/tile.xml
@@ -1,6 +1,8 @@
 <project>
     <properties>
         <java.version>@java.compiler.version@</java.version>
+        <maven.compiler.source>@java.compiler.version@</maven.compiler.source>
+        <maven.compiler.target>@java.compiler.version@</maven.compiler.target>
         <maven-compiler-plugin.version>@maven-compiler-plugin.version@</maven-compiler-plugin.version>
         <project.build.sourceEncoding>@project.build.sourceEncoding@</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
Without these properties IDEs like Intellij don't pick up on the fact that the maven-compile-plugin is configured for something other than JDK 5.