### PR TITLE
Add new tiles 'compiler-jdk-lts' and 'compiler-jdk-latest'

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,38 +64,30 @@ For Java 11 applications you can use the `all-jdk-11` tile:
 
 ### individual tiles
 
-The `all` tile gives you the same as:
+The available tiles are:
 
 ```xml
       <tiles>
         <tile>net.kemitix.tiles:maven-plugins:${kemitix-tiles.version}</tile>
         <tile>net.kemitix.tiles:enforcer:${kemitix-tiles.version}</tile>
         <tile>net.kemitix.tiles:compiler-jdk-8:${kemitix-tiles.version}</tile>
+        <tile>net.kemitix.tiles:compiler-jdk-11:${kemitix-tiles.version}</tile>
+        <tile>net.kemitix.tiles:compiler-jdk-14:${kemitix-tiles.version}</tile>
+        <tile>net.kemitix.tiles:compiler-jdk-15:${kemitix-tiles.version}</tile>
+        <tile>net.kemitix.tiles:compiler-jdk-lts:${kemitix-tiles.version}</tile>
+        <tile>net.kemitix.tiles:compiler-jdk-latest:${kemitix-tiles.version}</tile>
+        <tile>net.kemitix.tiles:compiler-jdk-next:${kemitix-tiles.version}</tile>
         <tile>net.kemitix.tiles:huntbugs:${kemitix-tiles.version}</tile>
         <tile>net.kemitix.tiles:pmd:${kemitix-tiles.version}</tile>
         <tile>net.kemitix.tiles:digraph:${kemitix-tiles.version}</tile>
         <tile>net.kemitix.tiles:testing:${kemitix-tiles.version}</tile>
         <tile>net.kemitix.tiles:coverage:${kemitix-tiles.version}</tile>
         <tile>net.kemitix.tiles:pitest:${kemitix-tiles.version}</tile>
+        <tile>net.kemitix.tiles:pmd-strict:${kemitix-tiles.version}</tile>
+        <tile>net.kemitix.tiles:scala-lang:${kemitix-tiles.version}</tile>
+        <tile>net.kemitix.tiles:frontend:${kemitix-tiles.version}</tile>
       </tiles>
 ```
-
-The `all-jdk-11` tile includes the same tiles as `all` excluding `huntbugs`
-and `pitest` and replacing `compiler-jdk-8` with `compiler-jdk-11`.
-
-The following tile is available, but is not included in either the `all` or
-`all-jdk-11` tiles:
-
-```xml
-<tiles>
-    <tile>net.kemitix.tiles:pmd-strict:${kemitix-tiles.version}</tile>
-    <tile>net.kemitix.tiles:scala-lang:${kemitix-tiles.version}</tile>
-    <tile>net.kemitix.tiles:frontend:${kemitix-tiles.version}</tile>
-</tiles>
-```
-
-For Java 11 use the individual tiles, replacing the `compile-jdk-8` with
-`compiler-jdk-11`.
 
 ## Tiles
 
@@ -132,12 +124,11 @@ Default is 3.5.4.
 mvn validate -Drequired-maven.version=3.3.9
 ```
 
-### Compiler JDK 8 and 11 Tiles
+### Compiler JDK Tiles
 
-Select either the `compiler-jdk-8` or `compiler-jdk-11` to select your Java
-compiler.
+Select the `compiler-jdk-*` tile to select your Java compiler.
 
-Both tiles configure the 
+All `compiler-jdk-*` tiles configure the 
 [maven-compiler-plugin](https://maven.apache.org/plugins/maven-compiler-plugin/)
 with the following options:
 

--- a/compiler-jdk-latest/pom.xml
+++ b/compiler-jdk-latest/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>net.kemitix.tiles</groupId>
+        <version>2.9.0</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>compiler-jdk-latest</artifactId>
+    <packaging>tile</packaging>
+
+    <name>kemitix-maven-tiles-compiler-jdk-latest</name>
+    <description>maven-compiler-plugin for kemitix-maven-tiles</description>
+
+    <properties>
+        <java.compiler.version>14</java.compiler.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/compiler-jdk-latest/tile.xml
+++ b/compiler-jdk-latest/tile.xml
@@ -1,0 +1,28 @@
+<project>
+    <properties>
+        <java.version>@java.compiler.version@</java.version>
+        <maven.compiler.source>@java.compiler.version@</maven.compiler.source>
+        <maven.compiler.target>@java.compiler.version@</maven.compiler.target>
+        <maven-compiler-plugin.version>@maven-compiler-plugin.version@</maven-compiler-plugin.version>
+        <project.build.sourceEncoding>@project.build.sourceEncoding@</project.build.sourceEncoding>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin><!-- maven-compiler-plugin -->
+        </plugins>
+    </build>
+</project>

--- a/compiler-jdk-lts/pom.xml
+++ b/compiler-jdk-lts/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>net.kemitix.tiles</groupId>
+        <version>2.9.0</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>compiler-jdk-lts</artifactId>
+    <packaging>tile</packaging>
+
+    <name>kemitix-maven-tiles-compiler-jdk-lts</name>
+    <description>maven-compiler-plugin for kemitix-maven-tiles</description>
+
+    <properties>
+        <java.compiler.version>11</java.compiler.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/compiler-jdk-lts/tile.xml
+++ b/compiler-jdk-lts/tile.xml
@@ -1,0 +1,28 @@
+<project>
+    <properties>
+        <java.version>@java.compiler.version@</java.version>
+        <maven.compiler.source>@java.compiler.version@</maven.compiler.source>
+        <maven.compiler.target>@java.compiler.version@</maven.compiler.target>
+        <maven-compiler-plugin.version>@maven-compiler-plugin.version@</maven-compiler-plugin.version>
+        <project.build.sourceEncoding>@project.build.sourceEncoding@</project.build.sourceEncoding>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin><!-- maven-compiler-plugin -->
+        </plugins>
+    </build>
+</project>

--- a/compiler-jdk-next/pom.xml
+++ b/compiler-jdk-next/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>net.kemitix.tiles</groupId>
+        <version>2.9.0</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>compiler-jdk-next</artifactId>
+    <packaging>tile</packaging>
+
+    <name>kemitix-maven-tiles-compiler-jdk-next</name>
+    <description>maven-compiler-plugin for kemitix-maven-tiles</description>
+
+    <properties>
+        <java.compiler.version>15</java.compiler.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/compiler-jdk-next/tile.xml
+++ b/compiler-jdk-next/tile.xml
@@ -1,0 +1,28 @@
+<project>
+    <properties>
+        <java.version>@java.compiler.version@</java.version>
+        <maven.compiler.source>@java.compiler.version@</maven.compiler.source>
+        <maven.compiler.target>@java.compiler.version@</maven.compiler.target>
+        <maven-compiler-plugin.version>@maven-compiler-plugin.version@</maven-compiler-plugin.version>
+        <project.build.sourceEncoding>@project.build.sourceEncoding@</project.build.sourceEncoding>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:unchecked</arg>
+                    </compilerArgs>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin><!-- maven-compiler-plugin -->
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
         <module>compiler-jdk-8</module>
         <module>compiler-jdk-11</module>
         <module>compiler-jdk-14</module>
+        <module>compiler-jdk-15</module>
+        <module>compiler-jdk-lts</module>
+        <module>compiler-jdk-latest</module>
+        <module>compiler-jdk-next</module>
         <module>digraph</module>
         <module>enforcer</module>
         <module>coverage</module>


### PR DESCRIPTION
The lts tile will initially be for JDK 8 and latest for 14. As new versions are released they will be updated. i.e. lts next updating to JDK 17 around September 2021 and latest to 15 around September 15.