### PR TITLE
Update compiler tiles for JDK 16 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Select the `compiler-jdk-*` tile to select your Java compiler.
 |---|---
 |8|8
 |lts|11
-|latest|15
-|next|16
+|latest|16
+|next|17
 
 All `compiler-jdk-*` tiles configure the 
 [maven-compiler-plugin](https://maven.apache.org/plugins/maven-compiler-plugin/)

--- a/compiler-jdk-latest/pom.xml
+++ b/compiler-jdk-latest/pom.xml
@@ -17,7 +17,7 @@
     <description>maven-compiler-plugin for kemitix-maven-tiles</description>
 
     <properties>
-        <java.compiler.version>15</java.compiler.version>
+        <java.compiler.version>16</java.compiler.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>

--- a/compiler-jdk-next/pom.xml
+++ b/compiler-jdk-next/pom.xml
@@ -17,7 +17,7 @@
     <description>maven-compiler-plugin for kemitix-maven-tiles</description>
 
     <properties>
-        <java.compiler.version>16</java.compiler.version>
+        <java.compiler.version>17</java.compiler.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>


### PR DESCRIPTION
`latest` becomes 16
`next` becomes 17