### PR TITLE
Create an empty version-tracker module

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Given:
         <tiles-maven-plugin.version>${LATEST-PLUGIN-VERSION}</tiles-maven-plugin.version>
         <kemitix-tiles.version>${LATEST-TILES-VERSION}</kemitix-tiles.version>
     </properties>
+    <dependencies>
+        <dependency>
+            <artifactId>version-tracker</artifactId>
+            <groupId>net.kemitix.tiles</groupId>
+            <version>${kemitix-tiles.version}</version>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>
@@ -55,6 +63,13 @@ Given:
     </build>
 </project>
 ```
+
+## Version Tracker
+
+The module `version-tracker` is provided to allow version monitors, such as dependabot, to see that this is a dependency upon this project, and provide a notification when an upgrade is available.
+Tiles are not recognised by such tools, so they don't provide notifications for them.
+
+The module itself is empty and is simply a marker to show that this is indeed a dependency upon this project.
 
 ## Tiles
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <module>pmd-strict</module>
         <module>spotbugs</module>
         <module>frontend</module>
+        <module>version-tracker</module>
     </modules>
 
 </project>

--- a/version-tracker/pom.xml
+++ b/version-tracker/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>net.kemitix.tiles</groupId>
+        <version>3.0.2</version>
+        <relativePath>../parent/pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>version-tracker</artifactId>
+
+    <description>An empty dependency to allow version trackers, such as dependabot, to see when an update is available.</description>
+
+</project>


### PR DESCRIPTION
This module would exist so that users of the tiles can optionally depend upon it and be notified by tools such as dependabot when it is upgraded. Dependabot and its kin don't recognise the use of tiles when looking for available upgrades.